### PR TITLE
Group: group authentication, mutual authentication

### DIFF
--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -6,7 +6,7 @@ contract Group{
         WAITING,
         VALID
     }
-    struct Requester{
+    struct Member{
         uint count;
         bool isValid;
     }
@@ -14,12 +14,12 @@ contract Group{
     address public owner; //group leader
     GroupStatus public status;
     
-    mapping(string => Requester) public requesters; //key: user did, value: Requester
+    mapping(string => Member) public members; //key: user did, value: Requester
 
     constructor(string memory _ownerDid) {
         owner = msg.sender;
-        requesters[_ownerDid].count = 0;
-        requesters[_ownerDid].isValid = true;
+        members[_ownerDid].count = 0;
+        members[_ownerDid].isValid = true;
 
         status = GroupStatus.INVALID;
     }
@@ -35,44 +35,44 @@ contract Group{
     //Request to join a group
     function requestMember(string memory _userDid) onlyValidGroup external{
         require(
-            requesters[_userDid].count == 0,
+            members[_userDid].count == 0,
             "Already request Member"
         );
 
-        requesters[_userDid].count = 0;
-        requesters[_userDid].isValid = false;
+        members[_userDid].count = 0;
+        members[_userDid].isValid = false;
     }
 
     //mutual authentication
     function approveMember(string memory _approverDid, string memory _requesterDid) onlyValidGroup external returns(bool){
         //Check Approver Permissions
         require(
-            requesters[_approverDid].isValid == true,
+            members[_approverDid].isValid == true,
             "No permission"
         );
         //Check if requester is already a member of the group
         require(
-           requesters[_requesterDid].isValid == false,
+           members[_requesterDid].isValid == false,
             "Already group member"
         );
         
-        requesters[_requesterDid].count++;
+        members[_requesterDid].count++;
         
-        if(requesters[_requesterDid].count>=2){
-            requesters[_requesterDid].isValid = true;
+        if(members[_requesterDid].count>=2){
+            members[_requesterDid].isValid = true;
         }
-        return requesters[_requesterDid].isValid;
+        return members[_requesterDid].isValid;
     }
 
     //Withdrawal
     function exitMember(string memory _requesterDid) onlyValidGroup external {
         //Check if requester is a member of the group
         require(
-           requesters[_requesterDid].isValid == true,
+           members[_requesterDid].isValid == true,
             "Not member"
         );
 
-        delete requesters[_requesterDid];
+        delete members[_requesterDid];
     }
 
     //group authentication
@@ -85,7 +85,7 @@ contract Group{
 
         //Check for duplicate approvers
         require(
-           requesters[_approverDid].isValid == false,
+           members[_approverDid].isValid == false,
             "can not approve"
         );
         
@@ -95,6 +95,6 @@ contract Group{
             status = GroupStatus.VALID;
         }
 
-        requesters[_approverDid].isValid = true;
+        members[_approverDid].isValid = true;
     }
 }

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -64,6 +64,20 @@ contract Group{
         return requesters[_requesterDid].isValid;
     }
 
+    //Withdrawal
+    function exitMember(string memory _requesterDid) onlyValidGroup external returns(bool) {
+        //Check if requester is a member of the group
+        require(
+           requesters[_requesterDid].isValid == true,
+            "Not member"
+        );
+
+        requesters[_requesterDid].count = 0;
+        requesters[_requesterDid].isValid = false;
+
+        return requesters[_requesterDid].isValid;
+    }
+
     //group authentication
     function approveGroupAuthentication(string memory _approverDid) external{
         //Check if the group is already approved

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -1,0 +1,60 @@
+pragma solidity >=0.7.0 <0.9.0;
+
+contract Group{
+    struct Requester{
+        uint count;
+        bool isValid;
+    }
+
+    address public owner; //그룹을 만든 사람
+
+    mapping(string => Requester) public requesters; //key: user account address, value: Requester
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    //그룹에 가입을 요청하는 것
+    function requestMember(string memory _userDid) external{
+        require(
+            requesters[_userDid].count == 0,
+            "Already request Member"
+        );
+
+        requesters[_userDid].count = 0;
+        requesters[_userDid].isValid = false;
+    }
+
+    //상호인증
+    function approveMember(string memory _approver, string memory _requester) external returns(bool){
+        //상호인증하는 사람의 권한 확인
+        require(
+            requesters[_approver].isValid == true,
+            "No permission"
+        );
+        //이미 승인 되었는지 확인
+        require(
+           requesters[_requester].isValid == false,
+            "Alreay group member"
+        );
+        
+        requesters[_requester].count++;
+        
+        if(requesters[_requester].count>=2){
+            requesters[_requester].isValid = true;
+        }
+        return requesters[_requester].isValid;
+    }
+
+    function getVaild(string memory _requester) external view returns (bool){
+        return requesters[_requester].isValid;
+    }
+
+    function setVaild(string memory _requester, bool _isValid) external{
+        requesters[_requester].isValid = _isValid;
+    }
+
+    function getCount(string memory _requester) external view returns (uint){
+        return requesters[_requester].count;
+    }
+}

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -1,14 +1,19 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 contract Group{
+    enum GroupStatus {
+        INVALID,
+        WAITING,
+        VALID
+    }
     struct Requester{
         uint count;
         bool isValid;
     }
 
     address public owner; //group leader
-    Requester public groupInfo;
-
+    GroupStatus public status;
+    
     mapping(string => Requester) public requesters; //key: user did, value: Requester
 
     constructor(string memory _ownerDid) {
@@ -16,13 +21,12 @@ contract Group{
         requesters[_ownerDid].count = 0;
         requesters[_ownerDid].isValid = true;
 
-        groupInfo.count = 0;
-        groupInfo.isValid = false;
+        status = GroupStatus.INVALID;
     }
 
     modifier onlyValidGroup{
         require(
-            groupInfo.isValid == true,
+            status == GroupStatus.VALID,
             "This function is restricted to the Valid group"
         );
         _;
@@ -61,10 +65,10 @@ contract Group{
     }
 
     //group authentication
-    function approveGroupAuthentication(string memory _approverDid) external returns(bool){
+    function approveGroupAuthentication(string memory _approverDid) external{
         //Check if the group is already approved
         require(
-           groupInfo.isValid == false,
+           status != GroupStatus.VALID,
             "Already approved group"
         );
 
@@ -74,13 +78,12 @@ contract Group{
             "can not approve"
         );
         
-        groupInfo.count++;
-        requesters[_approverDid].isValid = true;
-        
-        if(groupInfo.count>=2){
-            groupInfo.isValid = true;
+        if(status == GroupStatus.INVALID){
+            status = GroupStatus.WAITING;
+        }else if(status == GroupStatus.WAITING){
+            status = GroupStatus.VALID;
         }
 
-        return groupInfo.isValid;
+        requesters[_approverDid].isValid = true;
     }
 }

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -65,17 +65,14 @@ contract Group{
     }
 
     //Withdrawal
-    function exitMember(string memory _requesterDid) onlyValidGroup external returns(bool) {
+    function exitMember(string memory _requesterDid) onlyValidGroup external {
         //Check if requester is a member of the group
         require(
            requesters[_requesterDid].isValid == true,
             "Not member"
         );
 
-        requesters[_requesterDid].count = 0;
-        requesters[_requesterDid].isValid = false;
-
-        return requesters[_requesterDid].isValid;
+        delete requesters[_requesterDid];
     }
 
     //group authentication

--- a/migrations/2_Group_migration.js
+++ b/migrations/2_Group_migration.js
@@ -1,0 +1,5 @@
+const Group = artifacts.require("Group");
+
+module.exports = function (deployer){
+    deployer.deploy(Group);
+};

--- a/migrations/4_Group_migration.js
+++ b/migrations/4_Group_migration.js
@@ -1,5 +1,6 @@
 const Group = artifacts.require("Group");
+let _groupOwnerDid = "groupOwnerDid";
 
 module.exports = function (deployer){
-    deployer.deploy(Group);
+    deployer.deploy(Group, _groupOwnerDid);
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "truffle-assertions": "^0.9.2"
+  }
+}

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -20,8 +20,8 @@ contract("Group", function (accounts) {
         let valid = (await instance.requesters(_groupOwnerDid)).isValid;
         assert.equal(valid, true, "Group owner's valid is False");
 
-        let groupValid = (await instance.groupInfo()).isValid;
-        assert.equal(groupValid, false, "Group's Valid is True");
+        let status = await instance.status();
+        assert.equal(status, 0, "not equal status");
 
     });
 
@@ -48,8 +48,8 @@ contract("Group", function (accounts) {
 
         await instance.approveGroupAuthentication(_groupApprover1);
 
-        let groupCount = (await instance.groupInfo()).count;
-        assert.equal(groupCount, 1, "not equal count");
+        let status = await instance.status();
+        assert.equal(status, 1, "not equal status");
 
         let groupApprover1Valid = (await instance.requesters(_groupApprover1)).isValid;
         assert.equal(groupApprover1Valid, true, "not equal vaild");
@@ -69,8 +69,8 @@ contract("Group", function (accounts) {
 
         await instance.approveGroupAuthentication(_groupApprover2);
 
-        let groupValid = (await instance.groupInfo()).isValid;
-        assert.equal(groupValid, true, "not equal valid");
+        let status = await instance.status();
+        assert.equal(status, 2, "not equal status");
 
         let groupApprover2Valid = (await instance.requesters(_groupApprover2)).isValid;
         assert.equal(groupApprover2Valid, true, "not equal valid");

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -1,0 +1,45 @@
+const truffleAssert = require('truffle-assertions')
+const group = artifacts.require("Group")
+
+contract("Group", function (accounts){
+    it("is_user_works_well", async function(){
+        let instance = await group.deployed();
+        let owner = await instance.owner();
+
+        assert.equal(
+            owner.valueOf(),
+            accounts[0],
+            "Does not match owner"
+        )
+    });
+
+    it("is_requestMember_works_well", async() => {
+        //arrange
+        let instance = await group.deployed();
+        const userDid = "testing";
+
+        //act
+        await instance.requestMember(userDid);
+
+        //check
+        let count = await instance.getCount(userDid);
+        assert.equal(count, 0, "not equal count");
+    });
+
+    it("is_approveMember_works_well", async() => {
+        //arrange
+        let instance = await group.deployed();
+        const userDid = "testing";
+        await instance.setVaild(userDid, true)
+
+        const userDid2 = "testing2";
+        await instance.requestMember(userDid2);
+
+        //act
+        await instance.approveMember(userDid, userDid2);
+
+        //check
+        let count = await instance.getCount(userDid2);
+        assert.equal(count, 1, "not equal count");
+    });
+})

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -1,45 +1,123 @@
 const truffleAssert = require('truffle-assertions')
 const group = artifacts.require("Group")
 
-contract("Group", function (accounts){
-    it("is_user_works_well", async function(){
-        let instance = await group.deployed();
-        let owner = await instance.owner();
+contract("Group", function (accounts) {
+    const _groupOwnerDid = "groupOwnerDid";
+    const _groupApprover1 = "groupApprover1";
+    const _groupApprover2 = "groupApprover2";
+    const _userDid1 = "userDid1";
 
-        assert.equal(
-            owner.valueOf(),
-            accounts[0],
-            "Does not match owner"
-        )
-    });
-
-    it("is_requestMember_works_well", async() => {
+    it("Confirm_group_creation", async function () {
         //arrange
         let instance = await group.deployed();
-        const userDid = "testing";
-
+        
         //act
-        await instance.requestMember(userDid);
+        let owner = await instance.owner();
 
         //check
-        let count = await instance.getCount(userDid);
+        assert.equal(owner.valueOf(),accounts[0],"Does not match owner");
+
+        let valid = (await instance.requesters(_groupOwnerDid)).isValid;
+        assert.equal(valid, true, "Group owner's valid is False");
+
+        let groupValid = (await instance.groupInfo()).isValid;
+        assert.equal(groupValid, false, "Group's Valid is True");
+
+    });
+
+    it("request_to_join_before_completing_group_authentication", async () => {
+        let instance = await group.deployed();
+
+        await truffleAssert.reverts(
+            instance.requestMember(_userDid1),
+            "This function is restricted to the Valid group"
+        );
+    });
+
+    it("request_approval_before_completing_group_authentication", async () => {
+        let instance = await group.deployed();
+
+        await truffleAssert.reverts(
+            instance.approveMember(_userDid1, _groupOwnerDid),
+            "This function is restricted to the Valid group"
+        );
+    });
+
+    it("Group_authentication_by_1_person", async () => {
+        let instance = await group.deployed();
+
+        await instance.approveGroupAuthentication(_groupApprover1);
+
+        let groupCount = (await instance.groupInfo()).count;
+        assert.equal(groupCount, 1, "not equal count");
+
+        let groupApprover1Valid = (await instance.requesters(_groupApprover1)).isValid;
+        assert.equal(groupApprover1Valid, true, "not equal vaild");
+    });
+
+    it("Group_authentication_when_the_same_person_approves", async () => {
+        let instance = await group.deployed();
+
+        await truffleAssert.reverts(
+            instance.approveGroupAuthentication(_groupApprover1),
+            "can not approve"
+        );
+    });
+
+    it("Group_authentication_by_2_person", async () => {
+        let instance = await group.deployed();
+
+        await instance.approveGroupAuthentication(_groupApprover2);
+
+        let groupValid = (await instance.groupInfo()).isValid;
+        assert.equal(groupValid, true, "not equal valid");
+
+        let groupApprover2Valid = (await instance.requesters(_groupApprover2)).isValid;
+        assert.equal(groupApprover2Valid, true, "not equal valid");
+    });
+
+    it("Request_to_join_a_group", async () => {
+        let instance = await group.deployed();
+
+        await instance.requestMember(_userDid1);
+
+        let count = (await instance.requesters(_userDid1)).count;
         assert.equal(count, 0, "not equal count");
     });
 
-    it("is_approveMember_works_well", async() => {
-        //arrange
+    it("Approved_to_join_the_group_by_1_person", async() => {
         let instance = await group.deployed();
-        const userDid = "testing";
-        await instance.setVaild(userDid, true)
 
-        const userDid2 = "testing2";
-        await instance.requestMember(userDid2);
+        await instance.approveMember(_groupApprover1, _userDid1);
 
-        //act
-        await instance.approveMember(userDid, userDid2);
-
-        //check
-        let count = await instance.getCount(userDid2);
+        let count = (await instance.requesters(_userDid1)).count;
         assert.equal(count, 1, "not equal count");
     });
-})
+
+    it("Approved_to_join_the_group_if_the_approver_does_not_have_the_authority", async() => {
+        let instance = await group.deployed();
+
+        await truffleAssert.reverts(
+            instance.approveMember(_userDid1, _userDid1),
+            "No permission"
+        );
+    });
+
+    it("Approved_to_join_the_group_by_2_person", async() => {
+        let instance = await group.deployed();
+
+        await instance.approveMember(_groupApprover2, _userDid1);
+
+        let userDid1Valid = (await instance.requesters(_userDid1)).isValid;
+        assert.equal(userDid1Valid, true, "not equal valid");
+    });
+
+    it("Approved_to_join_the_group_if_already_approved", async() => {
+        let instance = await group.deployed();
+
+        await truffleAssert.reverts(
+            instance.approveMember(_groupApprover2, _userDid1),
+            "Already group member"
+        );
+    });
+});

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -6,6 +6,7 @@ contract("Group", function (accounts) {
     const _groupApprover1 = "groupApprover1";
     const _groupApprover2 = "groupApprover2";
     const _userDid1 = "userDid1";
+    const _userDid2 = "userDid2";
 
     it("Confirm_group_creation", async function () {
         //arrange
@@ -25,7 +26,7 @@ contract("Group", function (accounts) {
 
     });
 
-    it("request_to_join_before_completing_group_authentication", async () => {
+    it("Request_to_join_before_completing_group_authentication", async () => {
         let instance = await group.deployed();
 
         await truffleAssert.reverts(
@@ -34,11 +35,20 @@ contract("Group", function (accounts) {
         );
     });
 
-    it("request_approval_before_completing_group_authentication", async () => {
+    it("Request_approval_before_completing_group_authentication", async () => {
         let instance = await group.deployed();
 
         await truffleAssert.reverts(
             instance.approveMember(_userDid1, _groupOwnerDid),
+            "This function is restricted to the Valid group"
+        );
+    });
+
+    it("Request_exitMember_before_completing_group_authentication", async () => {
+        let instance = await group.deployed();
+
+        await truffleAssert.reverts(
+            instance.exitMember(_groupApprover1),
             "This function is restricted to the Valid group"
         );
     });
@@ -119,5 +129,26 @@ contract("Group", function (accounts) {
             instance.approveMember(_groupApprover2, _userDid1),
             "Already group member"
         );
+    });
+
+    it("Withdrawal_if_the__requester_does_not_member", async() => {
+        let instance = await group.deployed();
+
+        await truffleAssert.reverts(
+            instance.exitMember(_userDid2),
+            "Not member"
+        );
+    });
+
+    it("Withdrawal", async() => {
+        let instance = await group.deployed();
+
+        await instance.exitMember(_userDid1);
+        
+        let count = (await instance.requesters(_userDid1)).count;
+        assert.equal(count, 0, "not equal count");
+
+        let valid = (await instance.requesters(_userDid1)).isValid;
+        assert.equal(valid, false, "not equal valid");
     });
 });

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -144,9 +144,6 @@ contract("Group", function (accounts) {
         let instance = await group.deployed();
 
         await instance.exitMember(_userDid1);
-        
-        let count = (await instance.requesters(_userDid1)).count;
-        assert.equal(count, 0, "not equal count");
 
         let valid = (await instance.requesters(_userDid1)).isValid;
         assert.equal(valid, false, "not equal valid");

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -18,7 +18,7 @@ contract("Group", function (accounts) {
         //check
         assert.equal(owner.valueOf(),accounts[0],"Does not match owner");
 
-        let valid = (await instance.requesters(_groupOwnerDid)).isValid;
+        let valid = (await instance.members(_groupOwnerDid)).isValid;
         assert.equal(valid, true, "Group owner's valid is False");
 
         let status = await instance.status();
@@ -61,7 +61,7 @@ contract("Group", function (accounts) {
         let status = await instance.status();
         assert.equal(status, 1, "not equal status");
 
-        let groupApprover1Valid = (await instance.requesters(_groupApprover1)).isValid;
+        let groupApprover1Valid = (await instance.members(_groupApprover1)).isValid;
         assert.equal(groupApprover1Valid, true, "not equal vaild");
     });
 
@@ -82,7 +82,7 @@ contract("Group", function (accounts) {
         let status = await instance.status();
         assert.equal(status, 2, "not equal status");
 
-        let groupApprover2Valid = (await instance.requesters(_groupApprover2)).isValid;
+        let groupApprover2Valid = (await instance.members(_groupApprover2)).isValid;
         assert.equal(groupApprover2Valid, true, "not equal valid");
     });
 
@@ -91,7 +91,7 @@ contract("Group", function (accounts) {
 
         await instance.requestMember(_userDid1);
 
-        let count = (await instance.requesters(_userDid1)).count;
+        let count = (await instance.members(_userDid1)).count;
         assert.equal(count, 0, "not equal count");
     });
 
@@ -100,7 +100,7 @@ contract("Group", function (accounts) {
 
         await instance.approveMember(_groupApprover1, _userDid1);
 
-        let count = (await instance.requesters(_userDid1)).count;
+        let count = (await instance.members(_userDid1)).count;
         assert.equal(count, 1, "not equal count");
     });
 
@@ -118,7 +118,7 @@ contract("Group", function (accounts) {
 
         await instance.approveMember(_groupApprover2, _userDid1);
 
-        let userDid1Valid = (await instance.requesters(_userDid1)).isValid;
+        let userDid1Valid = (await instance.members(_userDid1)).isValid;
         assert.equal(userDid1Valid, true, "not equal valid");
     });
 
@@ -145,7 +145,7 @@ contract("Group", function (accounts) {
 
         await instance.exitMember(_userDid1);
 
-        let valid = (await instance.requesters(_userDid1)).isValid;
+        let valid = (await instance.members(_userDid1)).isValid;
         assert.equal(valid, false, "not equal valid");
     });
 });

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -18,8 +18,8 @@ contract("Group", function (accounts) {
         //check
         assert.equal(owner.valueOf(),accounts[0],"Does not match owner");
 
-        let valid = (await instance.members(_groupOwnerDid)).isValid;
-        assert.equal(valid, true, "Group owner's valid is False");
+        let ownderStatus = await instance.members(_groupOwnerDid);
+        assert.equal(ownderStatus, 3, "Group owner's valid is False");
 
         let status = await instance.status();
         assert.equal(status, 0, "not equal status");
@@ -61,8 +61,8 @@ contract("Group", function (accounts) {
         let status = await instance.status();
         assert.equal(status, 1, "not equal status");
 
-        let groupApprover1Valid = (await instance.members(_groupApprover1)).isValid;
-        assert.equal(groupApprover1Valid, true, "not equal vaild");
+        let groupApprover1Status = await instance.members(_groupApprover1);
+        assert.equal(groupApprover1Status, 3, "not equal status");
     });
 
     it("Group_authentication_when_the_same_person_approves", async () => {
@@ -82,8 +82,8 @@ contract("Group", function (accounts) {
         let status = await instance.status();
         assert.equal(status, 2, "not equal status");
 
-        let groupApprover2Valid = (await instance.members(_groupApprover2)).isValid;
-        assert.equal(groupApprover2Valid, true, "not equal valid");
+        let groupApprover2Status = await instance.members(_groupApprover2);
+        assert.equal(groupApprover2Status, 3, "not equal status");
     });
 
     it("Request_to_join_a_group", async () => {
@@ -91,8 +91,8 @@ contract("Group", function (accounts) {
 
         await instance.requestMember(_userDid1);
 
-        let count = (await instance.members(_userDid1)).count;
-        assert.equal(count, 0, "not equal count");
+        let status = await instance.members(_userDid1);
+        assert.equal(status, 1, "not equal status");
     });
 
     it("Approved_to_join_the_group_by_1_person", async() => {
@@ -100,8 +100,8 @@ contract("Group", function (accounts) {
 
         await instance.approveMember(_groupApprover1, _userDid1);
 
-        let count = (await instance.members(_userDid1)).count;
-        assert.equal(count, 1, "not equal count");
+        let status = await instance.members(_userDid1);
+        assert.equal(status, 2, "not equal status");
     });
 
     it("Approved_to_join_the_group_if_the_approver_does_not_have_the_authority", async() => {
@@ -118,8 +118,8 @@ contract("Group", function (accounts) {
 
         await instance.approveMember(_groupApprover2, _userDid1);
 
-        let userDid1Valid = (await instance.members(_userDid1)).isValid;
-        assert.equal(userDid1Valid, true, "not equal valid");
+        let status = await instance.members(_userDid1);
+        assert.equal(status, 3, "not equal status");
     });
 
     it("Approved_to_join_the_group_if_already_approved", async() => {
@@ -145,7 +145,7 @@ contract("Group", function (accounts) {
 
         await instance.exitMember(_userDid1);
 
-        let valid = (await instance.members(_userDid1)).isValid;
-        assert.equal(valid, false, "not equal valid");
+        let status = await instance.members(_userDid1);
+        assert.equal(status, 0, "not equal status");
     });
 });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -40,7 +40,13 @@ module.exports = {
     // You should run a client (like ganache-cli, geth or parity) in a separate terminal
     // tab if you use this network and you must also set the `host`, `port` and `network_id`
     // options below to some value.
-    //
+    
+    development: {
+      host: "127.0.0.1",   
+      port: 7545,           
+      network_id: 5777,   
+    }
+
     // development: {
     //  host: "127.0.0.1",     // Localhost (default: none)
     //  port: 8545,            // Standard Ethereum port (default: none)


### PR DESCRIPTION
## 개요
- 그룹 인증과 그룹원 상호 인증

## 상세내용
- 그룹이 생성될 때마다, Group contract가 하나 생성됩니다.
- 그룹장을 제외한 다른 2명이 그룹에 대한 인증을 해주어야 그룹 인증이 완료됩니다.
- 그룹장, 그룹 생성을 승인해준 2명은 isValid가 True입니다.
- 그룹에 가입하려고 할 때, 사용자의 DID가 필요합니다.
- 이미 그룹에 가입된 사람만 가입 요청 사용자를 승인해줄 수 있습니다.

## 리뷰어가 확인할 사항
- Test를 위한 `truffle-assertions`를 설치했습니다. `npm install truffle-assertions` (@0JIEUN0👍) ([참고](https://gitlab.ifi.uzh.ch/rodrigues/scflare/-/tree/master/Truffle/truffle-assertions))

## 기타
- requestMember() 에서 똑같은 사용자가 여러 번 가입을 요청하는 경우와 approveMember()에서 똑같은 승인자가 여러 번 승인을 하려는 경우의 예외 처리도 컨트랙트에서 해야 할 지 혹은 서버나 클라이언트에서 처리할 지 의견 남겨주세요
- 그리고 constructor에 매개변수인 _ownerDid를 넘겨야 하는데, migration에서 저렇게 넘겨주어도 될지도 의견 부탁드립니다!