### PR TITLE
Ballot: fix contract

### DIFF
--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -2,6 +2,12 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 contract Ballot {
+    enum BallotStatus {
+        OPEN,
+        ONGOING,
+        FINISHED
+    }
+
     struct Voter {
         uint weight;
         bool voted;
@@ -13,13 +19,27 @@ contract Ballot {
         uint voteCount;
     }
 
+    modifier atFinished {
+        require(
+            status == BallotStatus.FINISHED,
+            "This function is restricted only at finished status."
+        );
+        _;
+    }
+
+    BallotStatus public status;
     address public chairperson; // or group
 
     mapping(address => Voter) public voters;
-    Candidate[] public candidates;
+    Candidate[] private candidates;
+
+    function getResult() atFinished external returns (Candidate[]) {
+        return candidates;
+    }
 
     /// Create new ballot
     constructor(bytes32[] memory _candidateNames) {
+        status = BallotStatus.OPEN;
         chairperson = msg.sender;
         voters[chairperson].weight = 1;
 

--- a/migrations/3_Ballot_migration.js
+++ b/migrations/3_Ballot_migration.js
@@ -1,5 +1,5 @@
 const Ballot = artifacts.require("Ballot");
 
 module.exports = function (deployer) {
-    deployer.deploy(Ballot, ["0x53696c7665720000000000000000000000000000000000000000000000000000"]);
+    deployer.deploy(Ballot, ["0x53696c7665720000000000000000000000000000000000000000000000000000"], true);
 };

--- a/test/BallotTest.js
+++ b/test/BallotTest.js
@@ -80,6 +80,53 @@ contract("Ballot", function (accounts) {
         );
     })
 
+    it("is_vote_works_well", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+        let notOwner = accounts[2];
+
+        // act
+        let voters = [voter1, voter2]
+        await instance.vote(0, voter1, {from: notOwner})
+
+        // assert
+        let voter = await instance.voters(voter1)
+        assert.equal(voter.right, true)
+        assert.equal(voter.voted, true)
+
+        // TODO check candidate voteCount: ?
+    })
+    it("is_vote_reverts_when_already_voted", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act, assert: check revert when already voted voter
+        await truffleAssert.reverts(
+            instance.vote(0, voter1),
+            "Already voted."
+        );
+    })
+    it("is_vote_reverts_when_no_right_to_vote", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act, assert: check revert when no right to vote
+        await truffleAssert.reverts(
+            instance.vote(0, "not a voter"),
+            "Has no right to vote."
+        );
+    })
+    it("is_vote_reverts_when_invalid_candidate", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+
+        // act, assert: check revert when already voted voter
+        await truffleAssert.reverts(
+            instance.vote(1, voter2)
+        );
+    })
+
     it("is_close_works_well", async () => {
         // arrange
         let instance = await ballot.deployed();
@@ -114,6 +161,6 @@ contract("Ballot", function (accounts) {
         // assert
         assert.equal(result.length, 1, "number of candidate is wrong.")
         assert.equal(result[0].name, candidate1, "candidate name is wrong.")
-        assert.equal(result[0].voteCount, 0, "voteCount is wrong.")
+        assert.equal(result[0].voteCount, 1, "voteCount is wrong.")
     })
 })

--- a/test/BallotTest.js
+++ b/test/BallotTest.js
@@ -1,0 +1,119 @@
+const truffleAssert = require('truffle-assertions')
+const ballot = artifacts.require("Ballot")
+
+contract("Ballot", function (accounts) {
+    const candidate1 = "0x53696c7665720000000000000000000000000000000000000000000000000000";
+    const voter1 = "je"
+    const voter2 = "apt"
+
+    it("is_constructor_works_well", async function () {
+        // arrange
+        let instance = await ballot.deployed();
+        let status = await instance.status();
+        let chairperson = await instance.chairperson();
+
+        // assert
+        assert.equal(chairperson.valueOf(), accounts[0], "accounts[0] wasn't the contract owner(chairperson).")
+        assert.equal(status, 0) // BallotStatus.OPEN
+    })
+    it("is_candidates_not_works_well", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act, assert: check fail at call candidates (it is private)
+        try {
+            await instance.candidates(candidate1)
+            assert.fail("This should be failed...")
+        } catch (e) {
+            assert.equal(e instanceof TypeError, true)
+            assert.equal(e.message, "instance.candidates is not a function")
+        }
+    })
+    it("is_resultOfBallot_reverts_on_not_finished", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act, assert: check revert when not FINISHED status
+        await truffleAssert.reverts(
+            instance.resultOfBallot(),
+            "This function is restricted only at FINISHED status."
+        );
+    })
+
+    it("is_giveRightToVoters_works_well", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act
+        let voters = [voter1, voter2]
+        await instance.giveRightToVoters(voters)
+
+        // assert
+        for (const voter of voters) {
+            let v = await instance.voters(voter)
+            assert.equal(v.right, true)
+            assert.equal(v.voted, false)
+        }
+        // check status is ONGOING
+        let status = await instance.status();
+        assert.equal(status, 1) // BallotStatus.ONGOING
+    })
+    it("is_giveRightToVoters_reverts_on_not_chairperson", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+        let notOwner = accounts[1];
+
+        // act, assert: check revert when not owner(chairperson)
+        await truffleAssert.reverts(
+            instance.giveRightToVoters(["new voter"], {from: notOwner}),
+            "Only chairperson can give right to vote."
+        );
+    })
+    it("is_giveRightToVoters_reverts_on_called_twice", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act, assert: check revert when call twice
+        await truffleAssert.reverts(
+            instance.giveRightToVoters(["new voter"]),
+            "This function can only be called once."
+        );
+    })
+
+    it("is_close_works_well", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act
+        await instance.close();
+
+        // aseert
+        // check status is FINISHED
+        let status = await instance.status();
+        assert.equal(status, 2) // BallotStatus.FINISHED
+    })
+    it("is_close_reverts_when_not_chairperson", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+        let notOwner = accounts[1];
+
+        // act, assert: check revert when not owner(chairperson)
+        await truffleAssert.reverts(
+            instance.close({from: notOwner}),
+            "Only chairperson can close this ballot."
+        );
+    })
+
+    it("is_resultOfBallot_works_well", async () => {
+        // arrange
+        let instance = await ballot.deployed();
+
+        // act
+        let result = await instance.resultOfBallot();
+
+        // assert
+        assert.equal(result.length, 1, "number of candidate is wrong.")
+        assert.equal(result[0].name, candidate1, "candidate name is wrong.")
+        assert.equal(result[0].voteCount, 0, "voteCount is wrong.")
+    })
+})


### PR DESCRIPTION
## 개요
Ballot 컨트랙트 수정

## 상세
- `voters` 의 key 를 address 에서 did 로 변경 (추후 did 는 bytes32 로 변경 가능)
- `Voter` 정보에 `weight` 와 `vote` 정보를 없애고 `right` 를 추가
- Ballot Status 로 close 등 추가 구현
- 한 번만 투표권(right) 부여 가능 (`giveRightToVoters()`)
- 기존에 chairperson 에도 right 를 부여했는데, 이를 삭제
- Ballot 컨트랙트에 대한 test code 작성
- 익명 투표에 대한 이슈 (#2 ) 가 있지만, 일단 이렇게 두기로 합의
