### PR TITLE
DID: register, check Id

### DIFF
--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -3,12 +3,13 @@ pragma solidity >=0.7.0 <0.9.0;
 
 contract DecentralizedId {
     struct Id {
-        string id;
+        // 공개키 넣기 (address) - did 주인의 address
+        address owner;
         bool isValid;
     }
 
     address public owner;
-    mapping(string => Id) public ids;
+    mapping(string => Id) public ids; 
 
     modifier onlyOwner {
         require(
@@ -18,6 +19,7 @@ contract DecentralizedId {
         _;
     }
 
+    //배포하는 사람이 호출하는 것이 constructor
     constructor() {
         owner = msg.sender;
     }
@@ -31,7 +33,7 @@ contract DecentralizedId {
             checkRegistered(_id) == false,
             "Already registered ID."
         );
-        ids[_id].id = _id;
+        ids[_id].owner = owner;
         ids[_id].isValid = true;
     }
 

--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -32,7 +32,7 @@ contract DecentralizedId {
             checkRegistered(_id) == false,
             "Already registered ID."
         );
-        ids[_id].addr = owner;
+        ids[_id].addr = msg.sender;
         ids[_id].isValid = true;
     }
 

--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.7.0 <0.9.0;
 
 contract DecentralizedId {
     struct Id {
-        // 공개키 넣기 (address) - did 주인의 address
         address owner;
         bool isValid;
     }

--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.0 <0.9.0;
 
 contract DecentralizedId {
     struct Id {
-        address owner;
+        address addr;
         bool isValid;
     }
 
@@ -32,7 +32,7 @@ contract DecentralizedId {
             checkRegistered(_id) == false,
             "Already registered ID."
         );
-        ids[_id].owner = owner;
+        ids[_id].addr = owner;
         ids[_id].isValid = true;
     }
 

--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -27,7 +27,7 @@ contract DecentralizedId {
         return ids[_id].isValid;
     }
 
-    function registerId(string memory _id) onlyOwner external {
+    function registerId(string memory _id) external {
         require(
             checkRegistered(_id) == false,
             "Already registered ID."

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "DuckBox-SC",
   "version": "1.0.0",
   "dependencies": {
-    "@truffle/hdwallet-provider": "2.0.3",
+    "@truffle/hdwallet-provider": "^2.0.3",
     "dotenv": "16.0.0",
     "web3": "1.7.0"
   },

--- a/test/DecentralizedIdTest.js
+++ b/test/DecentralizedIdTest.js
@@ -53,7 +53,7 @@ contract("DecentralizedId", function (accounts) {
         assert.equal(id.addr, owner);
         assert.equal(id.isValid, true);
     })
-    it("is_removeId_works_well", async ()m => {
+    it("is_removeId_works_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();
 

--- a/test/DecentralizedIdTest.js
+++ b/test/DecentralizedIdTest.js
@@ -28,18 +28,6 @@ contract("DecentralizedId", function (accounts) {
             "Already registered ID."
         );
     })
-    it("is_registerId_reverts_well", async () => {
-        // arrange
-        let instance = await decentralizedId.deployed();
-        const did = "did.testing2";
-        let notOwner = accounts[1];
-
-        // act, assert: check revert when not owner
-        await truffleAssert.reverts(
-            instance.registerId(did, {from: notOwner}),
-            "This function is restricted to the contract's owner."
-        );
-    })
     it("is_getId_works_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();

--- a/test/DecentralizedIdTest.js
+++ b/test/DecentralizedIdTest.js
@@ -16,7 +16,7 @@ contract("DecentralizedId", function (accounts) {
     it("is_registerId_works_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();
-
+        
         // act, assert
         await instance.registerId(did);
         let id = await instance.ids(did);
@@ -44,12 +44,13 @@ contract("DecentralizedId", function (accounts) {
         // arrange
         let instance = await decentralizedId.deployed();
         let notOwner = accounts[1];
+        let owner = await instance.owner();
 
         // act
         const id = await instance.getId(did, {from: notOwner});
 
         // assert
-        assert.equal(id.id, did);
+        assert.equal(id.owner, owner);
         assert.equal(id.isValid, true);
     })
     it("is_removeId_works_well", async () => {

--- a/test/DecentralizedIdTest.js
+++ b/test/DecentralizedIdTest.js
@@ -50,10 +50,10 @@ contract("DecentralizedId", function (accounts) {
         const id = await instance.getId(did, {from: notOwner});
 
         // assert
-        assert.equal(id.owner, owner);
+        assert.equal(id.addr, owner);
         assert.equal(id.isValid, true);
     })
-    it("is_removeId_works_well", async () => {
+    it("is_removeId_works_well", async ()m => {
         // arrange
         let instance = await decentralizedId.deployed();
 


### PR DESCRIPTION
## 개요
-  회원가입과 사용자 계정 확인

## 상세내용
- 사용자는 회원가입 할 때, `registerId()`를 호출하며 사용자의 DID가 필요합니다.
- 오직 자신의 계정만 삭제 가능합니다. 
- 계정은 누구나 참조할 수 있습니다.
- 회원가입 하는 경우 사용자의 isValid는 false 여야 합니다. 
- ids의 key 값 : DID, value 값 : Id 으로 매핑 
