### PR TITLE
Fix Ballot contract: add startTime/endTime and Ballots

### DIFF
--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -1,6 +1,48 @@
 // SPDX-License-Identifier: DuckBox
 pragma solidity >=0.7.0 <0.9.0;
 
+contract Ballots {
+    struct BallotBox {
+        bool isValid;
+        Ballot ballot;
+    }
+    mapping(string => BallotBox) ballots;
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function registerBallot(
+        string memory _ballotId,
+        string[] memory _candidateNames,
+        bool _isOfficial,
+        uint256 _startTime, // milliseconds
+        uint256 _endTime, // milliseconds
+        string[] memory _voters
+    ) external returns (Ballot){
+
+        require(
+            ballots[_ballotId].isValid == false,
+            "Already registered ballot (id)."
+        );
+
+        ballots[_ballotId].isValid = true;
+        ballots[_ballotId].ballot = new Ballot(_candidateNames, _isOfficial, _startTime, _endTime, _voters);
+
+        return ballots[_ballotId].ballot;
+    }
+
+    function getBallot(string memory _ballotId) external view returns (Ballot) {
+        BallotBox memory ballotBox = ballots[_ballotId];
+        require(
+            ballotBox.isValid == true,
+            "Unregistered ballot (id)."
+        );
+        return ballotBox.ballot;
+    }
+}
+
 contract Ballot {
     enum BallotStatus {
         PREREGISTERED, // need?

--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -45,7 +45,6 @@ contract Ballots {
 
 contract Ballot {
     enum BallotStatus {
-        PREREGISTERED, // need?
         REGISTERED,
         OPEN,
         CLOSE

--- a/migrations/3_Ballot_migration.js
+++ b/migrations/3_Ballot_migration.js
@@ -1,5 +1,8 @@
 const Ballot = artifacts.require("Ballot");
 
+let startTime = Math.floor(Date.now() / 1000)
+let endTime = startTime + 100
+
 module.exports = function (deployer) {
-    deployer.deploy(Ballot, ["0x53696c7665720000000000000000000000000000000000000000000000000000"], true);
+    deployer.deploy(Ballot, ["candidate1"], true, startTime, endTime, ["voter1", "voter2"]);
 };

--- a/migrations/3_Ballot_migration.js
+++ b/migrations/3_Ballot_migration.js
@@ -1,8 +1,10 @@
-const Ballot = artifacts.require("Ballot");
+// const Ballot = artifacts.require("Ballot");
+const Ballots = artifacts.require("Ballots");
 
 let startTime = Math.floor(Date.now() / 1000)
 let endTime = startTime + 100
 
 module.exports = function (deployer) {
-    deployer.deploy(Ballot, ["candidate1"], true, startTime, endTime, ["voter1", "voter2"]);
+    // deployer.deploy(Ballot, ["candidate1"], true, startTime, endTime, ["voter1", "voter2"]);
+    deployer.deploy(Ballots);
 };

--- a/test/BallotTest.js
+++ b/test/BallotTest.js
@@ -129,8 +129,8 @@ contract("Ballot_official", function (accounts) {
 
 
     it("is_close_and_resultOfBallot_works_well", async () => {
-        // wait 3000ms
-        await new Promise(resolve => setTimeout(resolve, 10000))
+        // wait 15000ms
+        await new Promise(resolve => setTimeout(resolve, 15000))
 
         // act
         await instance.close();

--- a/test/BallotTest.js
+++ b/test/BallotTest.js
@@ -3,10 +3,9 @@ const ballot = artifacts.require("Ballot")
 
 const candidates = ["candidate1", "candidate2"]
 const voters = ["voter1", "voter2"]
-const PREREGISTERED = 0
-const REGISTERED = 1
-const OPEN = 2
-const CLOSE = 3
+const REGISTERED = 0
+const OPEN = 1
+const CLOSE = 2
 
 contract("Ballot_official", function (accounts) {
     let instance = null
@@ -138,7 +137,7 @@ contract("Ballot_official", function (accounts) {
 
         // aseert
         let status = await instance.status();
-        assert.equal(status, 3) // check status is CLOSE
+        assert.equal(status, CLOSE) // check status is CLOSE
 
         assert.equal(result.length, 2, "number of candidate is wrong.")
         assert.equal(result[0].name, candidates[0], "candidate name is wrong.")

--- a/test/BallotsTest.js
+++ b/test/BallotsTest.js
@@ -1,0 +1,47 @@
+const truffleAssert = require('truffle-assertions')
+const ballots = artifacts.require("Ballots")
+
+contract("Ballots", function (accounts) {
+    let owner = accounts[0]
+    let instance = null
+    let ballotId = "ballot id"
+    let startTime = Math.floor(Date.now() / 1000)
+    let endTime = startTime + 100
+    let candidates = ["candidate1", "candidate2"]
+    let voters = ["voter1", "voter2"]
+
+    it("is_constructor_works_well", async function () {
+        // get instance first
+        instance = await ballots.new({from: owner});
+
+        // assert
+        assert.equal(await instance.owner(), owner);
+    })
+    it("is_registerBallot_and_getBallot_works_well", async () => {
+        // arrange
+        let chairperson = accounts[1]
+
+        // act
+        await instance.registerBallot(
+            ballotId, candidates, true, startTime, endTime, voters,
+            {from: chairperson}
+        )
+        await instance.getBallot(ballotId)
+    })
+    it("is_registerBallot_reverts_duplicate_ballot", async () => {
+        // act & assert
+        await truffleAssert.reverts(
+            instance.registerBallot(
+                ballotId, candidates, true, startTime, endTime, voters
+            ),
+            "Already registered ballot (id)."
+        );
+    })
+    it("is_getBallot_reverts_invalid_ballotId", async () => {
+        // act & assert
+        await truffleAssert.reverts(
+            instance.getBallot("invalid ballot id"),
+            "Unregistered ballot (id)."
+        );
+    })
+})


### PR DESCRIPTION
## 개요
Ballot contract 수정

## 상세
- Ballot Contract 에 startTime/endTime 을 추가하여 startTime 이후에 `open()`,  endTime 이후에 `close()` 할 수 있도록 변경
- 기존에 투표권을 부여하는 함수가 따로 있었다면, 이를 삭제하고 constructor 에서 수행해주는 것으로 변경
- Ballot status 를 `REGISTERED`, `OPEN`, `CLOSE` 로 변경
- Ballots contract 추가: Ballot 들을 관리하기 위한
- test code 작성 완료