### PR TITLE
Refactor: Rroviding integrated service

### DIFF
--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -1,47 +1,5 @@
-// SPDX-License-Identifier: DuckBox
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
-
-contract Ballots {
-    struct BallotBox {
-        bool isValid;
-        Ballot ballot;
-    }
-    mapping(string => BallotBox) ballots;
-    address public owner;
-
-    constructor() {
-        owner = msg.sender;
-    }
-
-    function registerBallot(
-        string memory _ballotId,
-        string[] memory _candidateNames,
-        bool _isOfficial,
-        uint256 _startTime, // milliseconds
-        uint256 _endTime, // milliseconds
-        string[] memory _voters
-    ) external returns (Ballot){
-
-        require(
-            ballots[_ballotId].isValid == false,
-            "Already registered ballot (id)."
-        );
-
-        ballots[_ballotId].isValid = true;
-        ballots[_ballotId].ballot = new Ballot(_candidateNames, _isOfficial, _startTime, _endTime, _voters);
-
-        return ballots[_ballotId].ballot;
-    }
-
-    function getBallot(string memory _ballotId) external view returns (Ballot) {
-        BallotBox memory ballotBox = ballots[_ballotId];
-        require(
-            ballotBox.isValid == true,
-            "Unregistered ballot (id)."
-        );
-        return ballotBox.ballot;
-    }
-}
 
 contract Ballot {
     enum BallotStatus {

--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -39,7 +39,7 @@ contract Ballot {
             _startTime < _endTime && block.timestamp < _endTime,
             "The start time must be earlier than the end time."
         );
-        chairperson = msg.sender;
+        chairperson = tx.origin;
         isOfficial = _isOfficial;
         startTime = _startTime;
         endTime = _endTime;

--- a/contracts/Ballots.sol
+++ b/contracts/Ballots.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+import "./Ballot.sol";
+
+contract Ballots {
+    struct BallotBox {
+        bool isValid;
+        Ballot ballot;
+    }
+    mapping(string => BallotBox) ballots;
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function registerBallot(
+        string memory _ballotId,
+        string[] memory _candidateNames,
+        bool _isOfficial,
+        uint256 _startTime, // milliseconds
+        uint256 _endTime, // milliseconds
+        string[] memory _voters
+    ) external returns (Ballot){
+
+        require(
+            ballots[_ballotId].isValid == false,
+            "Already registered ballot (id)."
+        );
+
+        ballots[_ballotId].isValid = true;
+        ballots[_ballotId].ballot = new Ballot(_candidateNames, _isOfficial, _startTime, _endTime, _voters);
+
+        return ballots[_ballotId].ballot;
+    }
+
+    function getBallot(string memory _ballotId) external view returns (Ballot) {
+        BallotBox memory ballotBox = ballots[_ballotId];
+        require(
+            ballotBox.isValid == true,
+            "Unregistered ballot (id)."
+        );
+        return ballotBox.ballot;
+    }
+}

--- a/contracts/Ballots.sol
+++ b/contracts/Ballots.sol
@@ -11,7 +11,7 @@ contract Ballots {
     address public owner;
 
     constructor() {
-        owner = msg.sender;
+        owner = tx.origin;
     }
 
     function registerBallot(

--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: DuckBox
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
 contract DecentralizedId {
@@ -8,7 +8,7 @@ contract DecentralizedId {
     }
 
     address public owner;
-    mapping(string => Id) public ids; 
+    mapping(string => Id) public ids;
 
     modifier onlyOwner {
         require(
@@ -18,16 +18,15 @@ contract DecentralizedId {
         _;
     }
 
-    //배포하는 사람이 호출하는 것이 constructor
     constructor() {
         owner = msg.sender;
     }
 
-    function checkRegistered(string memory _id) internal view returns (bool) {
+    function checkRegistered(string memory _id) public view returns (bool) {
         return ids[_id].isValid;
     }
 
-    function registerId(string memory _id) external {
+    function registerId(string memory _id) onlyOwner external {
         require(
             checkRegistered(_id) == false,
             "Already registered ID."
@@ -38,13 +37,5 @@ contract DecentralizedId {
 
     function removeId(string memory _id) onlyOwner external {
         delete ids[_id];
-    }
-
-    function getId(string memory _id) external view returns (Id memory){
-        require(
-            checkRegistered(_id) == true,
-            "Invalid request for an unregistered ID."
-        );
-        return ids[_id];
     }
 }

--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -12,14 +12,14 @@ contract DecentralizedId {
 
     modifier onlyOwner {
         require(
-            msg.sender == owner,
+            owner == tx.origin,
             "This function is restricted to the contract's owner."
         );
         _;
     }
 
     constructor() {
-        owner = msg.sender;
+        owner = tx.origin;
     }
 
     function checkRegistered(string memory _id) public view returns (bool) {
@@ -31,7 +31,7 @@ contract DecentralizedId {
             checkRegistered(_id) == false,
             "Already registered ID."
         );
-        ids[_id].addr = msg.sender;
+        ids[_id].addr = tx.origin;
         ids[_id].isValid = true;
     }
 

--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -3,12 +3,12 @@ pragma solidity >=0.7.0 <0.9.0;
 
 contract DecentralizedId {
     struct Id {
-        address addr;
+        string id;
         bool isValid;
     }
 
     address public owner;
-    mapping(string => Id) public ids;
+    mapping(address => Id) public ids;
 
     modifier onlyOwner {
         require(
@@ -22,20 +22,20 @@ contract DecentralizedId {
         owner = tx.origin;
     }
 
-    function checkRegistered(string memory _id) public view returns (bool) {
-        return ids[_id].isValid;
+    function checkRegistered(address _address) public view returns (bool) {
+        return ids[_address].isValid;
     }
 
-    function registerId(string memory _id) onlyOwner external {
+    function registerId(address _address, string memory _id) onlyOwner external {
         require(
-            checkRegistered(_id) == false,
-            "Already registered ID."
+            checkRegistered(_address) == false,
+            "Already registered address."
         );
-        ids[_id].addr = tx.origin;
-        ids[_id].isValid = true;
+        ids[_address].id = _id;
+        ids[_address].isValid = true;
     }
 
-    function removeId(string memory _id) onlyOwner external {
-        delete ids[_id];
+    function removeId(address _address) onlyOwner external {
+        delete ids[_address];
     }
 }

--- a/contracts/DuckBox.sol
+++ b/contracts/DuckBox.sol
@@ -33,11 +33,11 @@ contract DuckBox {
 
 
     /// DecentralizedId
-    function registerDid(string memory _id) onlyOwner external returns (address){
+    function registerDid(string memory _id) external returns (address){
         did.registerId(_id);
         return msg.sender;
     }
-    function removeDid(string memory _id) onlyOwner external {
+    function removeDid(string memory _id) external {
         did.removeId(_id);
     }
     ///

--- a/contracts/DuckBox.sol
+++ b/contracts/DuckBox.sol
@@ -42,4 +42,37 @@ contract DuckBox {
     ///
 
 
+    /// Group
+
+    ///
+
+
+    /// Ballot
+    function registerBallot(
+        string memory _ballotId,
+        string[] memory _candidateNames,
+        bool _isOfficial,
+        uint256 _startTime, // milliseconds
+        uint256 _endTime, // milliseconds
+        string[] memory _voters
+    ) checkRegistered external returns (Ballot){
+
+        require(address(ballots[_ballotId]) == address(0));
+        ballots[_ballotId] = new Ballot(_candidateNames, _isOfficial, _startTime, _endTime, _voters);
+        return ballots[_ballotId];
+    }
+    function openBallot(string memory _ballotId) external {
+        require(address(ballots[_ballotId]) != address(0));
+        ballots[_ballotId].open();
+    }
+    function closeBallot(string memory _ballotId) external {
+        require(address(ballots[_ballotId]) != address(0));
+        ballots[_ballotId].close();
+    }
+    function getResultOfBallot(string memory _ballotId) external view returns (Ballot.Candidate[] memory candidates_){
+        require(address(ballots[_ballotId]) != address(0));
+        return ballots[_ballotId].resultOfBallot();
+    }
+    // TODO vote
+    ///
 }

--- a/contracts/DuckBox.sol
+++ b/contracts/DuckBox.sol
@@ -23,22 +23,21 @@ contract DuckBox {
         );
         _;
     }
-    modifier checkDid(string memory _id) {
+    modifier checkRegistered() {
         require(
-            did.checkRegistered(_id),
-            "Requested did is not registered."
+            did.checkRegistered(tx.origin),
+            "Not registered address."
         );
         _;
     }
 
 
     /// DecentralizedId
-    function registerDid(string memory _id) external returns (address){
-        did.registerId(_id);
-        return msg.sender;
+    function registerDid(address _address, string memory _id) external {
+        did.registerId(_address, _id);
     }
-    function removeDid(string memory _id) external {
-        did.removeId(_id);
+    function removeDid(address _address) external {
+        did.removeId(_address);
     }
     ///
 

--- a/contracts/DuckBox.sol
+++ b/contracts/DuckBox.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+import "./DecentralizedId.sol";
+import "./Ballot.sol";
+import "./Group.sol";
+
+contract DuckBox {
+    address public owner;
+    DecentralizedId public did;
+    mapping(string => Group) public groups;
+    mapping(string => Ballot) public ballots;
+
+    constructor() {
+        owner = msg.sender;
+        did = new DecentralizedId();
+    }
+
+    /// modifier
+    modifier onlyOwner {
+        require(
+            msg.sender == owner,
+            "This function is restricted to the contract's owner."
+        );
+        _;
+    }
+    modifier checkDid(string memory _id) {
+        require(
+            did.checkRegistered(_id),
+            "Requested did is not registered."
+        );
+        _;
+    }
+
+
+    /// DecentralizedId
+    function registerDid(string memory _id) onlyOwner external returns (address){
+        did.registerId(_id);
+        return msg.sender;
+    }
+    function removeDid(string memory _id) onlyOwner external {
+        did.removeId(_id);
+    }
+    ///
+
+
+}

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -11,17 +11,21 @@ contract Group{
     enum MemberStatus{
         INVALID,
         REQUEST,
-        WATING,
+        WAITING,
         VALID
     }
 
-    address public owner; //group leader
+    string public groupId;
+    string public owner; //group leader
     GroupStatus public status;
     
     mapping(string => MemberStatus) public members; //key: user did, value: Requester
 
-    constructor(string memory _ownerDid) {
-        owner = msg.sender;
+    event groupAuthCompleted(string groupId);
+
+    constructor(string memory _groupId, string memory _ownerDid) {
+        groupId = _groupId;
+        owner = _ownerDid;
         members[_ownerDid] = MemberStatus.VALID;
 
         status = GroupStatus.INVALID;
@@ -54,13 +58,13 @@ contract Group{
         );
         //Check if requester is already a member of the group
         require(
-           members[_requesterDid] == MemberStatus.REQUEST ||  members[_requesterDid] == MemberStatus.WATING,
+           members[_requesterDid] == MemberStatus.REQUEST ||  members[_requesterDid] == MemberStatus.WAITING,
             "Already group member"
         );
         
         if(members[_requesterDid] == MemberStatus.REQUEST){
-            members[_requesterDid] = MemberStatus.WATING;
-        }else if(members[_requesterDid] == MemberStatus.WATING){
+            members[_requesterDid] = MemberStatus.WAITING;
+        }else if(members[_requesterDid] == MemberStatus.WAITING){
             members[_requesterDid] = MemberStatus.VALID;
         }
     }
@@ -94,6 +98,7 @@ contract Group{
             status = GroupStatus.WAITING;
         }else if(status == GroupStatus.WAITING){
             status = GroupStatus.VALID;
+            emit groupAuthCompleted(groupId); // emit event for notify group status is changed to VALID
         }
 
         members[_approverDid] = MemberStatus.VALID;

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
 contract Group{

--- a/migrations/4_Group_migration.js
+++ b/migrations/4_Group_migration.js
@@ -1,6 +1,7 @@
 const Group = artifacts.require("Group");
+let _groupId = "groupId";
 let _groupOwnerDid = "groupOwnerDid";
 
 module.exports = function (deployer){
-    deployer.deploy(Group, _groupOwnerDid);
+    deployer.deploy(Group, _groupId, _groupOwnerDid);
 };

--- a/migrations/5_DuckBox_migration.js
+++ b/migrations/5_DuckBox_migration.js
@@ -1,0 +1,5 @@
+const DuckBox = artifacts.require("DuckBox");
+
+module.exports = function (deployer){
+    deployer.deploy(DuckBox);
+};

--- a/test/DecentralizedIdTest.js
+++ b/test/DecentralizedIdTest.js
@@ -28,18 +28,19 @@ contract("DecentralizedId", function (accounts) {
             "Already registered ID."
         );
     })
-    it("is_getId_works_well", async () => {
+    it("is_registerId_reverts_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();
+        let didtmp = "did.testing.id"
         let notOwner = accounts[1];
-        let owner = await instance.owner();
 
-        // act
-        const id = await instance.getId(did, {from: notOwner});
-
-        // assert
-        assert.equal(id.addr, owner);
-        assert.equal(id.isValid, true);
+        // act, assert: check revert when not owner
+        await truffleAssert.reverts(
+            instance.registerId(didtmp, {from: notOwner}),
+            "This function is restricted to the contract's owner."
+        );
+        let id = await instance.ids(didtmp);
+        assert.equal(id.isValid, false)
     })
     it("is_removeId_works_well", async () => {
         // arrange

--- a/test/DecentralizedIdTest.js
+++ b/test/DecentralizedIdTest.js
@@ -16,56 +16,60 @@ contract("DecentralizedId", function (accounts) {
     it("is_registerId_works_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();
-        
+        let userAddress = accounts[3];
+
         // act, assert
-        await instance.registerId(did);
-        let id = await instance.ids(did);
+        await instance.registerId(userAddress, did);
+        let id = await instance.ids(userAddress);
         assert.equal(id.isValid, true)
 
         // check re-register revert
         await truffleAssert.reverts(
-            instance.registerId(did),
-            "Already registered ID."
+            instance.registerId(userAddress, did),
+            "Already registered address."
         );
     })
     it("is_registerId_reverts_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();
+        let userAddress = accounts[4];
         let didtmp = "did.testing.id"
         let notOwner = accounts[1];
 
         // act, assert: check revert when not owner
         await truffleAssert.reverts(
-            instance.registerId(didtmp, {from: notOwner}),
+            instance.registerId(userAddress, didtmp, {from: notOwner}),
             "This function is restricted to the contract's owner."
         );
-        let id = await instance.ids(didtmp);
+        let id = await instance.ids(userAddress);
         assert.equal(id.isValid, false)
     })
     it("is_removeId_works_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();
+        let userAddress = accounts[3];
 
         // act
-        await instance.removeId(did);
+        await instance.removeId(userAddress);
 
         // assert
-        let id = await instance.ids(did);
+        let id = await instance.ids(userAddress);
         assert.equal(id.isValid, false)
     })
     it("is_removeId_reverts_well", async () => {
         // arrange
         let instance = await decentralizedId.deployed();
+        let userAddress = accounts[4];
         let didtmp = "did.testing.tmp"
         let notOwner = accounts[1];
-        await instance.registerId(didtmp);
+        await instance.registerId(userAddress, didtmp);
 
         // act, assert: check revert when not owner
         await truffleAssert.reverts(
-            instance.removeId(didtmp, {from: notOwner}),
+            instance.removeId(userAddress, {from: notOwner}),
             "This function is restricted to the contract's owner."
         );
-        let id = await instance.ids(didtmp);
+        let id = await instance.ids(userAddress);
         assert.equal(id.isValid, true)
     })
 })

--- a/test/DuckBoxTest.js
+++ b/test/DuckBoxTest.js
@@ -1,0 +1,43 @@
+const truffleAssert = require('truffle-assertions')
+const duckbox = artifacts.require("DuckBox")
+
+
+contract("DuckBox-did", function (accounts) {
+    let owner = accounts[0]
+    let instance = null
+    let testdid = "test.did"
+
+    it("is_constructor_works_well", async function () {
+        // get instance first
+        instance = await duckbox.new({from: owner});
+
+        // assert
+        assert.equal(await instance.owner(), owner);
+        assert.notEqual(await instance.did(), 0)
+    })
+    it("is_registerDid_works_well", async function () {
+        // act & assert
+        await instance.registerDid(testdid)
+        await truffleAssert.reverts(
+            instance.registerDid(testdid),
+            "Already registered ID."
+        );
+    })
+    it("is_removeDid_works_well", async function () {
+        await instance.removeDid(testdid);
+    })
+    it("is_did_reverts_well_since_onlyOwner", async function () {
+        let notOwner = accounts[1];
+        let testdid2 = "test.did2"
+
+        // act & assert
+        await truffleAssert.reverts(
+            instance.registerDid(testdid2, {from: notOwner}),
+            "This function is restricted to the contract's owner."
+        );
+        await truffleAssert.reverts(
+            instance.removeDid(testdid2, {from: notOwner}),
+            "This function is restricted to the contract's owner."
+        );
+    })
+})

--- a/test/DuckBoxTest.js
+++ b/test/DuckBoxTest.js
@@ -5,6 +5,7 @@ const duckbox = artifacts.require("DuckBox")
 contract("DuckBox-did", function (accounts) {
     let owner = accounts[0]
     let instance = null
+    let userAddress = accounts[3]
     let testdid = "test.did"
 
     it("is_constructor_works_well", async function () {
@@ -17,26 +18,27 @@ contract("DuckBox-did", function (accounts) {
     })
     it("is_registerDid_works_well", async function () {
         // act & assert
-        await instance.registerDid(testdid)
+        await instance.registerDid(userAddress, testdid)
         await truffleAssert.reverts(
-            instance.registerDid(testdid),
-            "Already registered ID."
+            instance.registerDid(userAddress, testdid),
+            "Already registered address."
         );
     })
     it("is_removeDid_works_well", async function () {
-        await instance.removeDid(testdid);
+        await instance.removeDid(userAddress);
     })
     it("is_did_reverts_well_since_onlyOwner", async function () {
         let notOwner = accounts[1];
+        let userAddress2 = accounts[4];
         let testdid2 = "test.did2"
 
         // act & assert
         await truffleAssert.reverts(
-            instance.registerDid(testdid2, {from: notOwner}),
+            instance.registerDid(userAddress2, testdid2, {from: notOwner}),
             "This function is restricted to the contract's owner."
         );
         await truffleAssert.reverts(
-            instance.removeDid(testdid2, {from: notOwner}),
+            instance.removeDid(userAddress2, {from: notOwner}),
             "This function is restricted to the contract's owner."
         );
     })

--- a/test/DuckBoxTest.js
+++ b/test/DuckBoxTest.js
@@ -43,3 +43,71 @@ contract("DuckBox-did", function (accounts) {
         );
     })
 })
+
+
+contract("DuckBox-ballot", function (accounts) {
+    let owner = accounts[0]
+    let instance = null
+    let ballotId = "ballot id"
+    let startTime = Math.floor(Date.now() / 1000) + 10
+    let endTime = startTime + 20
+    let candidates = ["candidate1", "candidate2"]
+    let voters = ["voter1", "voter2"]
+    let chairperson = accounts[1]
+
+    it("is_constructor_works_well", async function () {
+        // get instance first
+        instance = await duckbox.new({from: owner});
+
+        // assert
+        assert.equal(await instance.owner(), owner);
+        assert.notEqual(await instance.did(), 0)
+    })
+    it("is_registerBallot_reverts_unregistered_address", async () => {
+        // arrange
+        // act
+        await truffleAssert.reverts(
+            instance.registerBallot(
+                ballotId, candidates, true, startTime, endTime, voters,
+                {from: chairperson}
+            )
+        )
+    })
+    it("is_registerBallot_works_well", async () => {
+        // arrange
+        await instance.registerDid(chairperson, "test");
+
+        // act
+        let ballot = await instance.registerBallot(
+            ballotId, candidates, true, startTime, endTime, voters,
+            {from: chairperson}
+        )
+        assert.equal(await instance.owner(), owner);
+    })
+    it("is_registerBallot_reverts_duplicate_ballot", async () => {
+        // act & assert
+        await truffleAssert.reverts(
+            instance.registerBallot( // register with same ballot id
+                ballotId, candidates, true, startTime, endTime, voters
+            )
+        );
+    })
+    it("is_open_works_well", async () => {
+        // wait 3000ms
+        await new Promise(resolve => setTimeout(resolve, 10000))
+
+        // act
+        await instance.openBallot(ballotId)
+    })
+    it("is_close_and_getResultOfBallot_works_well", async () => {
+        // wait 15000ms
+        await new Promise(resolve => setTimeout(resolve, 15000))
+
+        // act
+        await instance.closeBallot(ballotId);
+        let result = await instance.getResultOfBallot(ballotId);
+
+        // aseert
+        assert.equal(result.length, 2, "number of candidate is wrong.")
+    })
+})


### PR DESCRIPTION
## 개요
기존의 contract 수정 및 통합 서비스 제공을 위한 `DuckBox` contract 작성

## 상세
- DecentralizedId: register, remove 모두 owner 만 가능하도록 변경 / 기존 `string => Id` 매핑에서 `address => Id` 로 변경
- Group: `groupId` 를 저장 / `groupAuthCompleted` event 를 `status` 가 `VALID` 로 바뀔 경우 emit 하는 것 추가
- 종속된 contract 들에서 `msg.sender` 를 `tx.origin` 으로 변경. (후자는 transaction 을 작성한 address)
- DuckBox contract 에 DecentralizedId, Ballot 을 모두 지원하도록 작성 완료
    - address 중심으로 수정한 것이 개념적으로, 기능적으로 받아들여지면 Group 도 수정 및 반영 예정
    - (회의에서 같이 의논해봅시다! 여기에 의견을 남겨주셔도 좋구요.)
