### PR TITLE
Check Group DID

### DIFF
--- a/contracts/DecentralizedId.sol
+++ b/contracts/DecentralizedId.sol
@@ -26,6 +26,10 @@ contract DecentralizedId {
         return ids[_address].isValid;
     }
 
+    function getDid(address _address) public view returns (string memory){
+        return ids[_address].id;
+    }
+
     function registerId(address _address, string memory _id) onlyOwner external {
         require(
             checkRegistered(_address) == false,

--- a/contracts/DuckBox.sol
+++ b/contracts/DuckBox.sol
@@ -30,6 +30,13 @@ contract DuckBox {
         );
         _;
     }
+    modifier checkDid(string memory _did){
+        require(
+            keccak256(bytes(did.getDid(tx.origin))) == keccak256(bytes(_did)),
+            "Dose not match Did"
+        );
+        _;
+    }
 
 
     /// DecentralizedId
@@ -43,7 +50,45 @@ contract DuckBox {
 
 
     /// Group
+    function registerGroup( //request owner
+        string memory _groupId, 
+        string memory _ownerDid
+    ) checkDid(_ownerDid) checkRegistered external{
+        groups[_groupId] = new Group(_groupId, _ownerDid);
+    }
 
+    function requestGroupMember( //request requester
+        string memory _groupId, 
+        string memory _userDid
+    ) checkDid(_userDid) checkRegistered external{
+        groups[_groupId].requestMember(_userDid);
+    }
+
+    function approveGroupMember( //request approver
+        string memory _groupId, 
+        string memory _approverDid, 
+        string memory _requesterDid
+    ) checkRegistered external{
+        groups[_groupId].approveMember(_approverDid, _requesterDid);
+    }
+
+    function exitMember( //reqeust requester
+        string memory _groupId, 
+        string memory _requesterDid
+    ) checkRegistered external {
+        groups[_groupId].exitMember(_requesterDid);
+    }
+
+    function approveGroupAuthentication( //request approver
+        string memory _groupId, 
+        string memory _approverDid
+    ) checkDid(_approverDid) checkRegistered external {
+        groups[_groupId].approveGroupAuthentication(_approverDid);
+    }
+
+    function getMemberStatus(string memory _groupId, string memory _did) external view returns (Group.MemberStatus _status){
+        _status = groups[_groupId].getMemberStatus(_did);
+    }
     ///
 
 

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -103,4 +103,8 @@ contract Group{
 
         members[_approverDid] = MemberStatus.VALID;
     }
+
+    function getMemberStatus(string memory did) external view returns (MemberStatus _status){
+        _status = members[did];
+    }
 }

--- a/test/DuckBoxTest.js
+++ b/test/DuckBoxTest.js
@@ -3,10 +3,10 @@ const duckbox = artifacts.require("DuckBox")
 
 
 contract("DuckBox-did", function (accounts) {
-    let owner = accounts[0]
-    let instance = null
-    let userAddress = accounts[3]
-    let testdid = "test.did"
+    let owner = accounts[0];
+    let instance = null;
+    let userAddress = accounts[3];
+    let testdid = "test.did";
 
     it("is_constructor_works_well", async function () {
         // get instance first
@@ -14,23 +14,23 @@ contract("DuckBox-did", function (accounts) {
 
         // assert
         assert.equal(await instance.owner(), owner);
-        assert.notEqual(await instance.did(), 0)
-    })
+        assert.notEqual(await instance.did(), 0);
+    });
     it("is_registerDid_works_well", async function () {
         // act & assert
-        await instance.registerDid(userAddress, testdid)
+        await instance.registerDid(userAddress, testdid);
         await truffleAssert.reverts(
             instance.registerDid(userAddress, testdid),
             "Already registered address."
         );
-    })
+    });
     it("is_removeDid_works_well", async function () {
         await instance.removeDid(userAddress);
-    })
+    });
     it("is_did_reverts_well_since_onlyOwner", async function () {
         let notOwner = accounts[1];
         let userAddress2 = accounts[4];
-        let testdid2 = "test.did2"
+        let testdid2 = "test.did2";
 
         // act & assert
         await truffleAssert.reverts(
@@ -41,19 +41,19 @@ contract("DuckBox-did", function (accounts) {
             instance.removeDid(userAddress2, {from: notOwner}),
             "This function is restricted to the contract's owner."
         );
-    })
-})
+    });
+});
 
 
 contract("DuckBox-ballot", function (accounts) {
-    let owner = accounts[0]
-    let instance = null
-    let ballotId = "ballot id"
-    let startTime = Math.floor(Date.now() / 1000) + 10
-    let endTime = startTime + 20
-    let candidates = ["candidate1", "candidate2"]
-    let voters = ["voter1", "voter2"]
-    let chairperson = accounts[1]
+    let owner = accounts[0];
+    let instance = null;
+    let ballotId = "ballot id";
+    let startTime = Math.floor(Date.now() / 1000) + 10;
+    let endTime = startTime + 20;
+    let candidates = ["candidate1", "candidate2"];
+    let voters = ["voter1", "voter2"];
+    let chairperson = accounts[1];
 
     it("is_constructor_works_well", async function () {
         // get instance first
@@ -61,8 +61,8 @@ contract("DuckBox-ballot", function (accounts) {
 
         // assert
         assert.equal(await instance.owner(), owner);
-        assert.notEqual(await instance.did(), 0)
-    })
+        assert.notEqual(await instance.did(), 0);
+    });
     it("is_registerBallot_reverts_unregistered_address", async () => {
         // arrange
         // act
@@ -71,8 +71,8 @@ contract("DuckBox-ballot", function (accounts) {
                 ballotId, candidates, true, startTime, endTime, voters,
                 {from: chairperson}
             )
-        )
-    })
+        );
+    });
     it("is_registerBallot_works_well", async () => {
         // arrange
         await instance.registerDid(chairperson, "test");
@@ -81,9 +81,9 @@ contract("DuckBox-ballot", function (accounts) {
         let ballot = await instance.registerBallot(
             ballotId, candidates, true, startTime, endTime, voters,
             {from: chairperson}
-        )
+        );
         assert.equal(await instance.owner(), owner);
-    })
+    });
     it("is_registerBallot_reverts_duplicate_ballot", async () => {
         // act & assert
         await truffleAssert.reverts(
@@ -91,14 +91,14 @@ contract("DuckBox-ballot", function (accounts) {
                 ballotId, candidates, true, startTime, endTime, voters
             )
         );
-    })
+    });
     it("is_open_works_well", async () => {
         // wait 3000ms
         await new Promise(resolve => setTimeout(resolve, 10000))
 
         // act
         await instance.openBallot(ballotId)
-    })
+    });
     it("is_close_and_getResultOfBallot_works_well", async () => {
         // wait 15000ms
         await new Promise(resolve => setTimeout(resolve, 15000))
@@ -109,5 +109,166 @@ contract("DuckBox-ballot", function (accounts) {
 
         // aseert
         assert.equal(result.length, 2, "number of candidate is wrong.")
+    });
+});
+
+contract("DuckBox-group", function (accounts) {
+    let instance = null;
+    let groupID = "group id";
+    
+    let owner = accounts[0];
+    let groupApprover = [accounts[1], accounts[2]];
+    let user = [accounts[3], accounts[4]];
+
+    let ownerDid = "ownerDid";
+    let groupApproverDid = ["groupApprover1", "groupApprover2"];
+    let userDid = ["userDid1", "userDid2"];
+
+    it("is_constructor_works_well", async function () {
+        // get instance first
+        instance = await duckbox.new({from: owner});
+
+        // assert
+        assert.equal(await instance.owner(), owner);
+        assert.notEqual(await instance.did(), 0)
+    });
+
+    it("is_registerGroup_reverts_checkDid", async () => {
+        // act & assert
+        await truffleAssert.reverts(
+            instance.registerGroup( // owner do not register did
+            groupID, ownerDid, {from: owner}
+            ), "Dose not match Did"
+        );
+    });
+
+    it("is_registerGroup_works_well", async () => {
+        // arrange
+        await instance.registerDid(owner, ownerDid, {from: owner});
+
+        // act
+        await instance.registerGroup(groupID, ownerDid, {from: owner});
+        
+        // assert
+        let ownerStatus = await instance.getMemberStatus(groupID, ownerDid);
+        assert.equal(ownerStatus, 3);
+    });
+
+    it("is_approveGroupAuthentication_reverts_checkDid_by_approver0", async () => {
+        // act & assert
+        await truffleAssert.reverts(
+            instance.approveGroupAuthentication(
+                groupID, groupApproverDid[0], {from: groupApprover[0]}
+            ), "Dose not match Did"
+        );
+    });
+
+    it("is_approveGroupAuthentication_work_well_by_approver0", async () => {
+        //arrange
+        await instance.registerDid(groupApprover[0], groupApproverDid[0], {from: owner});
+        
+        await instance.approveGroupAuthentication(groupID, groupApproverDid[0], {from: groupApprover[0]});
+
+        // assert
+        let approverStatus = await instance.getMemberStatus(groupID, groupApproverDid[0]);
+        assert.equal(approverStatus, 3);
+    });
+
+    it("is_approveGroupAuthentication_reverts_checkDid_by_approver1", async () => {
+        // act & assert
+        await truffleAssert.reverts(
+            instance.approveGroupAuthentication(
+                groupID, groupApproverDid[1], {from: groupApprover[1]}
+            ), "Dose not match Did"
+        );
+    });
+
+    it("is_approveGroupAuthentication_work_well_by_approver1", async () => {
+        //arrange
+        await instance.registerDid(groupApprover[1], groupApproverDid[1], {from: owner});
+        
+        //act
+        await instance.approveGroupAuthentication(groupID, groupApproverDid[1], {from: groupApprover[1]});
+
+        // assert
+        let approverStatus = await instance.getMemberStatus(groupID, groupApproverDid[1]);
+        assert.equal(approverStatus, 3);
     })
-})
+
+    it("is_requestGroupMember_reverts_checkDid", async () => {
+        // act & assert
+        await truffleAssert.reverts(
+            instance.requestGroupMember(
+                groupID, userDid[0], {from: user[0]}
+            ), "Dose not match Did"
+        );
+    });
+
+    it("is_requestGroupMember_work_well", async () => {
+        //arrange
+        await instance.registerDid(user[0], userDid[0], {from: owner});
+
+        // act
+        await instance.requestGroupMember(groupID, userDid[0], {from: user[0]});
+
+        //assert
+        let requestStatus = await instance.getMemberStatus(groupID, userDid[0]);
+        assert.equal(requestStatus, 1);
+    });
+
+    it("is_approved_to_join_the_group_by_1_person", async() => {
+        //act
+        await instance.approveGroupMember(groupID, groupApproverDid[0], userDid[0], {from: groupApprover[0]});
+
+        //assert
+        let requestStatus = await instance.getMemberStatus(groupID, userDid[0]);
+        assert.equal(requestStatus, 2);
+    });
+
+    it("is_approved_to_join_the_group_if_the_approver_does_not_have_the_authority", async() => {
+        //act & assert
+        await truffleAssert.reverts(
+            instance.approveGroupMember(
+                groupID, userDid[0], userDid[0], {from: user[0]}
+            )
+        );
+    });
+
+    it("is_approved_to_join_the_group_by_2_person", async() => {
+        //act
+        await instance.approveGroupMember(groupID, groupApproverDid[1], userDid[0], {from: groupApprover[1]});
+
+        //assert
+        let requestStatus = await instance.getMemberStatus(groupID, userDid[0]);
+        assert.equal(requestStatus, 3);
+    });
+
+    it("is_approved_to_join_the_group_if_already_approved", async() => {
+        //act & assert
+        await truffleAssert.reverts(
+            instance.approveGroupMember(
+                groupID, groupApproverDid[1], userDid[0], {from: groupApprover[1]}
+            )
+        );
+    });
+
+    it("is_withdrawal_if_the__requester_does_not_member", async() => {
+        //arrange
+        await instance.registerDid(user[1], userDid[1], {from: owner});
+
+        //act & assert
+        await truffleAssert.reverts(
+            instance.exitMember(groupID, userDid[1], {from: user[1]}
+            )
+        );
+    });
+
+    it("is_withdrawal", async() => {
+        //act
+        await instance.exitMember(groupID, userDid[0], {from: user[0]});
+        
+        //assert
+        let requestStatus = await instance.getMemberStatus(groupID, userDid[0]);
+        assert.equal(requestStatus, 0);
+    });
+});


### PR DESCRIPTION
## 개요
트랜잭션을 요청하는 사용자의 DID가 일치하는 지 확인하는 Group 컨트랙트

## 상세
- 그룹의 key는 did로 유지하되, 트랜잭션을 실행할 때마다 사용자의 DID를 확인하는 `require`추가
- DID는 string이기 때문에 문자열 비교를 해야 하는데, 솔리디티에서는 문자열 비교를 지원하지 않습니다. 따라서 `keccak256` 으로 해쉬하여 값이 같은지 비교하는 리스크가 큰 작업을 거치게 됩니다.
- 따라서 모든 함수에서 문자열을 비교하게 된다면, 혹은 `DuckBox`에 모든 함수를 모아둔다면 아래와 같은 경고가 나타납니다.  
 `Warning: Contract code size is 24690 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.`
- 그래서 문자열 비교는 해당 그룹을 처음 만들 때, 그룹을 인증하는 인증자가 처음 들어올 때, 그룹 멤버로 요청할 때만 실행하도록 했습니다.
- 지금 `DuckBox` 컨트랙트의 code size가 최대이며 아직 작업량이 남아있기 때문에, 하나의 컨트랙트에 몰아두는 게 괜찮은 지 논의가 필요합니다!
