### PR TITLE
group/groups: add events for mutual authentication

### DIFF
--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -21,6 +21,7 @@ contract Group{
     Requester[] public requesters;
 
     event groupAuthCompleted(string groupId);
+    event memberAuthCompleted(string groupId, bytes32 did);
 
     constructor(string memory _groupId, bytes32 _ownerDid) {
         groupId = _groupId;
@@ -91,6 +92,8 @@ contract Group{
                     members[_requesterDid] = true;
                     //delete array
                     remove(i);
+                    // emit event
+                    emit memberAuthCompleted(groupId, _requesterDid);
                 }
                 break;
             }

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -71,7 +71,7 @@ contract Group{
     }
 
     //mutual authentication
-    function approveMember(bytes32 _approverDid, bytes32 _requesterDid) onlyValidGroup external{
+    function approveMember(bytes32 _approverDid, bytes32 _requesterDid) onlyValidGroup external returns (bool) {
         //Check Approver Permissions
         require(
             members[_approverDid] == true,
@@ -98,6 +98,8 @@ contract Group{
                 break;
             }
         }
+
+        return members[_requesterDid];
     }
 
     function remove(uint index) internal {
@@ -125,7 +127,7 @@ contract Group{
     }
 
     //group authentication
-    function approveGroupAuthentication(bytes32 _approverDid) external{
+    function approveGroupAuthentication(bytes32 _approverDid) external returns (bool) {
         //Check if the group is already approved
         require(
            status != GroupStatus.VALID,
@@ -137,15 +139,17 @@ contract Group{
            members[_approverDid] != true,
             "can not approve"
         );
-        
+
+        members[_approverDid] = true;
+
         if(status == GroupStatus.INVALID){
             status = GroupStatus.WAITING;
         }else if(status == GroupStatus.WAITING){
             status = GroupStatus.VALID;
             emit groupAuthCompleted(groupId); // emit event for notify group status is changed to VALID
+            return true;
         }
-
-        members[_approverDid] = true;
+        return false;
     }
 
 }

--- a/contracts/Groups.sol
+++ b/contracts/Groups.sol
@@ -13,6 +13,9 @@ contract Groups {
     address public owner;
     address public didAddress;
 
+    event groupAuthCompleted(string groupId);
+    event memberAuthCompleted(string groupId, bytes32 did);
+
     constructor(address _didAddress) {
         owner = tx.origin;
         didAddress = _didAddress;
@@ -68,7 +71,8 @@ contract Groups {
             "Unregistered group (id)."
         );
 
-        groupBox.group.approveMember(_approverDid, _requesterDid);
+        bool result = groupBox.group.approveMember(_approverDid, _requesterDid);
+        if(result) emit memberAuthCompleted(_groupId, _requesterDid);
     }
 
     function exitMember(string memory _groupId, bytes32 _requesterDid) checkDid(_requesterDid) external{
@@ -88,7 +92,8 @@ contract Groups {
             "Unregistered group (id)."
         );
 
-        groupBox.group.approveGroupAuthentication(_approverDid);
+        bool result = groupBox.group.approveGroupAuthentication(_approverDid);
+        if(result) emit groupAuthCompleted(_groupId);
     }
 
     function getRequesterList(string memory _groupId) external view returns(Group.Requester[] memory requesters_){

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -95,11 +95,14 @@ contract("Group", function (accounts) {
 
     it("Approved_to_join_the_group_by_1_person", async() => {
         //act
-        await instance.approveMember(approverDid[0], userDid[0], {from: approver[0]});
+        let tx = await instance.approveMember(approverDid[0], userDid[0], {from: approver[0]});
     
         //check
         let status = await instance.getRequesterVaild(0);
         assert.equal(status, true, "not equal status");
+
+        // check event was not emitted
+        truffleAssert.eventNotEmitted(tx, 'memberAuthCompleted');
     });
 
     it("Approved_to_join_the_group_if_the_approver_does_not_have_the_authority", async() => {
@@ -111,11 +114,16 @@ contract("Group", function (accounts) {
 
     it("Approved_to_join_the_group_by_2_person", async() => {
         //act
-        await instance.approveMember(approverDid[1], userDid[0], {from: approver[1]});
+        let tx = await instance.approveMember(approverDid[1], userDid[0], {from: approver[1]});
 
         //check
         let status = await instance.members(userDid[0]);
         assert.equal(status, true, "not equal status");
+
+        // check event was emitted
+        truffleAssert.eventEmitted(tx, 'memberAuthCompleted', (ev) => {
+            return ev.groupId === groupID && ev.did === userDid[0];
+        });
     });
 
     it("Approved_to_join_the_group_if_already_approved", async() => {

--- a/test/GroupsTest.js
+++ b/test/GroupsTest.js
@@ -67,11 +67,14 @@ contract("Groups", function (accounts) {
         await didInstance.registerId(approver[0], approverDid[0]);
 
         //act
-        await instance.approveGroupAuthentication(groupID, approverDid[0], {from: approver[0]});
+        let tx = await instance.approveGroupAuthentication(groupID, approverDid[0], {from: approver[0]});
 
         //assert
         let status = await instance.getMemberStatus(groupID, approverDid[0]);
         assert.equal(status, true);
+
+        // check event not emitted
+        truffleAssert.eventNotEmitted(tx, 'groupAuthCompleted');
     });
 
     it("requestMember_reverts_befor_join_did", async () => {
@@ -98,11 +101,16 @@ contract("Groups", function (accounts) {
         await didInstance.registerId(approver[1], approverDid[1]);
 
         //act
-        await instance.approveGroupAuthentication(groupID, approverDid[1], {from: approver[1]});
+        let tx = await instance.approveGroupAuthentication(groupID, approverDid[1], {from: approver[1]});
     
         //assert
         let status = await instance.getMemberStatus(groupID, approverDid[1]);
         assert.equal(status, true);
+
+        // check event was emitted
+        truffleAssert.eventEmitted(tx, 'groupAuthCompleted', (ev) => {
+            return ev.groupId === groupID;
+        });
     });
 
     it("requestMember_works_well", async () => {
@@ -125,17 +133,20 @@ contract("Groups", function (accounts) {
 
     it("approveMember_work_well", async () => {
         // act & assert
-        await instance.approveMember(groupID, approverDid[0], userDid[0], {from: approver[0]})
+        let tx = await instance.approveMember(groupID, approverDid[0], userDid[0], {from: approver[0]})
     
         //assert
         let list = await instance.getRequesterList(groupID);
         assert.equal(list[0][0], userDid[0]);
         assert.equal(list[0][1], true);
+
+        // check event not emitted
+        truffleAssert.eventNotEmitted(tx, 'memberAuthCompleted');
     });
 
     it("approveMember_work_well2", async () => {
         // act & assert
-        await instance.approveMember(groupID, approverDid[1], userDid[0], {from: approver[1]})
+        let tx = await instance.approveMember(groupID, approverDid[1], userDid[0], {from: approver[1]})
     
         //assert
         let list = await instance.getRequesterList(groupID);
@@ -143,6 +154,11 @@ contract("Groups", function (accounts) {
 
         let status = await instance.getMemberStatus(groupID, userDid[0]);
         assert.equal(status, true);
+
+        // check event was emitted
+        truffleAssert.eventEmitted(tx, 'memberAuthCompleted', (ev) => {
+            return ev.groupId === groupID && ev.did === userDid[0];
+        });
     });
 
 


### PR DESCRIPTION
## 개요
`Group` contract 에서 member 에 대한 상호 인증이 완료 시 event 발생, `Groups` contract 에 event 들 반영

## 상세 내용
- `Group` contract 에서 member (요청) 에 대한 상호 인증이 완료되면 event `memberAuthCompleted` 를 발생시키는 것 추가
- `Groups` contract 에서 event `groupAuthCompleted`, `memberAuthCompleted` 추가 및 반영 완료
- 이로 인해 `Groups` contract 를 ropsten 에 새로 배포하였고 공유하였으니, 확인바랍니다!

