### PR TITLE
fix: Group,Groups add-user-name-and-email-at-requestMember

### DIFF
--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -12,6 +12,8 @@ contract Group{
     struct Requester{
         bytes32 did;
         bool isValid;
+        string name;
+        string email;
     }
 
     string public groupId;
@@ -47,7 +49,7 @@ contract Group{
     }
 
     //Request to join a group
-    function requestMember(bytes32 _userDid) onlyValidGroup external{
+    function requestMember(bytes32 _userDid, string memory _name, string memory _email) onlyValidGroup external{
         require(
             members[_userDid] == false,
             "Already group Member"
@@ -66,7 +68,9 @@ contract Group{
 
         requesters.push(Requester({
                 did: _userDid,
-                isValid: false
+                isValid: false,
+                name: _name,
+                email: _email
             }));
     }
 

--- a/contracts/Groups.sol
+++ b/contracts/Groups.sol
@@ -54,14 +54,14 @@ contract Groups {
     }
 
     //Group function
-    function requestMember(string memory _groupId, bytes32 _userDid) checkDid(_userDid) external{
+    function requestMember(string memory _groupId, bytes32 _userDid, string memory _name, string memory _email) checkDid(_userDid) external{
         GroupBox memory groupBox = groups[_groupId];
         require(
             groupBox.isValid == true,
             "Unregistered group (id)."
         );
 
-        groupBox.group.requestMember(_userDid);
+        groupBox.group.requestMember(_userDid, _name, _email);
     }
 
     function approveMember(string memory _groupId, bytes32 _approverDid, bytes32 _requesterDid)  checkDid(_approverDid) external{

--- a/test/GroupTest.js
+++ b/test/GroupTest.js
@@ -31,7 +31,7 @@ contract("Group", function (accounts) {
 
     it("Request_to_join_before_completing_group_authentication", async () => {
         await truffleAssert.reverts(
-            instance.requestMember(userDid[0]),
+            instance.requestMember(userDid[0], "name", "email"),
             "This function is restricted to the Valid group"
         );
     });
@@ -86,7 +86,7 @@ contract("Group", function (accounts) {
 
     it("Request_to_join_a_group", async () => {
         //act
-        await instance.requestMember(userDid[0], {from: user[0]});
+        await instance.requestMember(userDid[0], "name", "email", {from: user[0]});
 
         //check
         let status = await instance.getRequesterVaild(0);

--- a/test/GroupsTest.js
+++ b/test/GroupsTest.js
@@ -80,7 +80,7 @@ contract("Groups", function (accounts) {
     it("requestMember_reverts_befor_join_did", async () => {
         // act & assert
         await truffleAssert.reverts(
-            instance.requestMember(groupID, userDid[0], {from: user[0]}),
+            instance.requestMember(groupID, userDid[0], "name", "email", {from: user[0]}),
             "faild to transfer ether"
         );
     });
@@ -91,7 +91,7 @@ contract("Groups", function (accounts) {
 
         // act & assert
         await truffleAssert.reverts(
-            instance.requestMember(groupID, userDid[0], {from: user[0]}),
+            instance.requestMember(groupID, userDid[0], "name", "email", {from: user[0]}),
             "restricted to the Valid group"
         );
     });
@@ -115,7 +115,7 @@ contract("Groups", function (accounts) {
 
     it("requestMember_works_well", async () => {
         //act
-        await instance.requestMember(groupID, userDid[0], {from: user[0]});
+        await instance.requestMember(groupID, userDid[0], "name", "email", {from: user[0]});
 
         //assert
         let list = await instance.getRequesterList(groupID);


### PR DESCRIPTION
## 개요
- 그룹에서 그룹 가입 요청을 할 때 닉네임과 이메일 정보를 받도록 변경

## 상세 내용
- 상호인증 화면 상에서 사용자를 구별하기 위해 이메일과 닉네임을 컨트랙트에 저장합니다.

