### PR TITLE
fix(ballot): change to return uint256[] instead of Candidate[]

### DIFF
--- a/contracts/Ballot.sol
+++ b/contracts/Ballot.sol
@@ -99,12 +99,16 @@ contract Ballot {
         else revert("Before the end time.");
     }
 
-    function resultOfBallot() external view returns (Candidate[] memory candidates_) {
+    function resultOfBallot() external view returns (uint[] memory) {
         require(
             status == BallotStatus.CLOSE,
             "This function is restricted only at CLOSE status."
         );
-        candidates_ = candidates;
+        uint[] memory result = new uint[](candidates.length);
+        for (uint i=0; i<candidates.length; i++) {
+            result[i] = candidates[i].voteCount;
+        }
+        return result;
     }
 
     function vote(bytes memory _m, uint256 _serverSig, uint256 _ownerSig, uint256[2] memory R) external {

--- a/contracts/Ballots.sol
+++ b/contracts/Ballots.sol
@@ -74,8 +74,8 @@ contract Ballots {
         ballots[_ballotId].ballot.close(_totalNum);
     }
 
-    function resultOfBallot(string memory _ballotId) external view returns (Ballot.Candidate[] memory candidates_) {
-        candidates_ = ballots[_ballotId].ballot.resultOfBallot();
+    function resultOfBallot(string memory _ballotId) external view returns (uint[] memory) {
+        return ballots[_ballotId].ballot.resultOfBallot();
     }
 
     function vote(

--- a/test/BallotTest.js
+++ b/test/BallotTest.js
@@ -114,8 +114,8 @@ contract("Ballot_official", function (accounts) {
         assert.equal(status, CLOSE); // check status is CLOSE
 
         assert.equal(result.length, 2, "number of candidate is wrong.");
-        assert.equal(result[0].name, candidates[0], "candidate name is wrong.");
-        assert.equal(result[0].voteCount, 1, "voteCount is wrong.");
+        //assert.equal(result[0].name, candidates[0], "candidate name is wrong.");
+        assert.equal(result[0], 1, "voteCount is wrong.");
     });
 });
 

--- a/test/BallotsTest.js
+++ b/test/BallotsTest.js
@@ -108,6 +108,6 @@ contract("Ballots", function (accounts) {
 
         // aseert
         assert.equal(result.length, 2, "number of candidate is wrong.");
-        assert.equal(result[0].voteCount, 1, "voteCount is wrong.");
+        assert.equal(result[0], 1, "voteCount is wrong.");
     });
 });


### PR DESCRIPTION
## 개요
`Ballot` contract 에서 결과를 변환할 때 `Candidate[]` 이 아닌 `uint[]` 를 반환하도록 수정

## 상세
투표의 결과값만 받으면 되기도 하고, kotlin 기반에서 Candidate 구조체를 정의하고 받아오는 작업이 단순하지 않아서 uint[] 를 반환하는 방향으로 수정했습니다.