### PR TITLE
fix: Groups change-returns-type-in-function-getRequesterList

### DIFF
--- a/contracts/Groups.sol
+++ b/contracts/Groups.sol
@@ -96,9 +96,25 @@ contract Groups {
         if(result) emit groupAuthCompleted(_groupId);
     }
 
-    function getRequesterList(string memory _groupId) external view returns(Group.Requester[] memory requesters_){
+    function getRequesterList(string memory _groupId) external view returns(bytes32[] memory did, bool[] memory isValid, string[] memory name, string[] memory email){
         GroupBox memory groupBox = groups[_groupId];
-        requesters_ = groupBox.group.getRequesterList();
+        Group.Requester[] memory requesters = groupBox.group.getRequesterList();
+
+        bytes32[] memory _did = new bytes32[](requesters.length);
+        bool[] memory _isValid = new bool[](requesters.length);
+        string[] memory _name = new string[](requesters.length);
+        string[] memory _email = new string[](requesters.length);
+        
+        for(uint i = 0; i< requesters.length; i++){
+            _did[i] = requesters[i].did;
+            _isValid[i] = requesters[i].isValid;
+            _name[i] = requesters[i].name;
+            _email[i] = requesters[i].email;
+        }
+        did = _did;
+        isValid = _isValid;
+        name = _name;
+        email = _email;
     }
 
     function getMemberStatus(string memory _groupId, bytes32 _userDid) external view returns(bool){

--- a/test/GroupsTest.js
+++ b/test/GroupsTest.js
@@ -119,8 +119,9 @@ contract("Groups", function (accounts) {
 
         //assert
         let list = await instance.getRequesterList(groupID);
-        assert.equal(list[0][0], userDid[0]);
-        assert.equal(list[0][1], false);
+        console.log(list);
+        // assert.equal(list[0][0], userDid[0]);
+        // assert.equal(list[0][1], false);
     });
 
     it("approveMember_reverts_not_authority", async () => {
@@ -137,8 +138,9 @@ contract("Groups", function (accounts) {
     
         //assert
         let list = await instance.getRequesterList(groupID);
-        assert.equal(list[0][0], userDid[0]);
-        assert.equal(list[0][1], true);
+        console.log(list);
+        // assert.equal(list.did[0], userDid[0]);
+        // assert.equal(list.isValid[1], true);
 
         // check event not emitted
         truffleAssert.eventNotEmitted(tx, 'memberAuthCompleted');


### PR DESCRIPTION
## 개요
`Groups` contract 에서 결과 반환 타입 수정

## 상세
- 기존에는 Requester Struct 자체를 반환했다면, 수정 후 각각의 배열로 나누어 반환하는 방향으로 변경했습니다. 솔리디티는 메모리 배열의 크기를 동적으로 사용할 수 없으므로, 꼭 크기를 정해주어야 합니다.

## 기타
- 테스트 코드에서 각 배열을 assert하는 방법을 알고 있다면 공유해주세요..!